### PR TITLE
Add HowTo100M preprocessing and readme (and sneak in pre-commit)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-yaml
+        args: ['--unsafe']
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+  - repo: https://github.com/psf/black
+    rev: 22.10.0
+    hooks:
+      - id: black
+        args:
+          - --line-length=120
+        # It is recommended to specify the latest version of Python
+        # supported by your project here, or alternatively use
+        # pre-commit's default_language_version, see
+        # https://pre-commit.com/#top_level-default_language_version
+        language_version: python3
+  - repo: https://github.com/pycqa/flake8
+    rev: 5.0.4  # pick a git hash / tag to point to
+    hooks:
+    -   id: flake8
+        args:
+          - "--max-line-length=120"
+          - "--ignore=E203,E266,E501,W503,F403,F401,E402,F405,F821"

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Other features are available:
 
 When running the script for the first time, you can decide to either associate your metrics to your account or log them anonymously.
 
-You can also log in (or create an account) before by running `wandb login`.	
+You can also log in (or create an account) before by running `wandb login`.
 
 ## For development
 
@@ -255,15 +255,16 @@ to run tests:
 ```bash
 pip install -r requirements-test.txt
 ```
-then 
+then
 ```bash
 make lint
 make test
 ```
 
-You can use `make black` to reformat the code
-
 `python -m pytest -x -s -v tests -k "dummy"` to run a specific test
+
+formatting:
+Please use `pre-commit` (`pip install pre-commit` and then `pre-commit install`) so that code is automatically linted when committing.
 
 ## Citation
 ```bibtex

--- a/swiss_ai/datasets/HDVILA.md
+++ b/swiss_ai/datasets/HDVILA.md
@@ -63,3 +63,68 @@ This should run at a speed of roughly 500 videos/min or 40 GB/min. For further s
 
 Also, note that unlike in [dataset_examples/HDVILA.md](/dataset_examples/HDVILA.md) we're not performing cut detection while downloading (at least in the default clariden download config). Cut detection seemed to slow things down considerably and we rather want to perform any such processing on the final combined dataset.
 
+# [HDVILA-100M](https://github.com/microsoft/XPretrain/tree/main/hd-vila-100m)
+Page adapted from [dataset_examples/HDVILA.md](/dataset_examples/HDVILA.md).
+
+HDVILA 100M is a dataset of 3.3M high-resolution videos from YouTube, divided into 100M clips.
+
+## Download the metdata
+First, run `wget -O hdvila100m.zip https://hdvila.blob.core.windows.net/dataset/hdvila100m.zip?sp=r&st=2022-06-28T03:33:11Z&se=2026-01-01T11:33:11Z&spr=https&sv=2021-06-08&sr=b&sig=VaqQkLFDqKinfkaPNs1jJ1EQIYCB%2FUPYiqFqmjWye6Y%3D` to download the HD VILA 100M metadata. Next, just run `unzip hdvilla100m.zip` in order to unzip the metadata. You should now have an `hdvila100m/` directory.
+
+Next, we need to do some preprocessing to get this metadata formatted into a nice parquet. The following script will take the downloaded metadata `.jsonl` files and create a parquet with all the relevant information.
+
+```python
+import pandas as pd
+import glob
+import json
+import os
+import time
+from datetime import datetime
+
+def time_string_to_seconds(timestamp):
+    hh,mm,s = timestamp.split(':')
+    ss,ms = s.split('.')
+    time = 3600*int(hh) +  60*int(mm) + int(ss) + int(ms)/1000
+    return time
+
+def convert_clip_list(clip_list):
+    return [[time_string_to_seconds(x) for x in clip] for clip in clip_list]
+
+parquet_dir = "/path/to/my/metadata/dir/"
+
+data = []
+for jsonl in sorted(glob.glob(f"{parquet_dir}*.jsonl")):
+    path = os.path.join(parquet_dir, jsonl)
+    with open(path, "r") as f:
+        for line in f:
+            json_obj = json.loads(line)
+            clips = [
+                json_obj['clip'][i]['span']
+                for i in range(len(json_obj['clip']))
+            ]
+
+            out = {
+                'video_id': json_obj['video_id'],
+                'url': json_obj['url'],
+                'clips': clips
+            }
+            data.append(out)
+
+df = pd.DataFrame(data)
+df['clips'] = df['clips'].map(lambda x: convert_clip_list(x))
+df.to_parquet("hd_vila.parquet")
+```
+
+Once you run this, you should have a file `hd_vila.parquet` with all the relevant metadata.
+
+## Download the Videos
+To download the videos on clariden, just run video2dataset with the [default download config for clariden](../configs/download_clariden.yaml): From the login node, execute the following command, adapting the paths if necessary
+
+```
+video2dataset --url_list="hd_vila.parquet" --config="swissai/configs/download_clariden.yaml" --output_folder="./hd_vila_v2d" --input_format="parquet" --output_format="webdataset" --url_col="url" --encode_formats="{'video': 'mp4', 'audio':'m4a'}" 
+```
+
+This should run at a speed of roughly 500 videos/min or 40 GB/min. For further speedups, consider parallelizing over more nodes.
+
+Also, note that unlike in [dataset_examples/HDVILA.md](/dataset_examples/HDVILA.md) we're not performing cut detection while downloading (at least in the default clariden download config). Cut detection seemed to slow things down considerably and we rather want to perform any such processing on the final combined dataset.
+

--- a/swiss_ai/datasets/HDVILA.md
+++ b/swiss_ai/datasets/HDVILA.md
@@ -56,75 +56,9 @@ Once you run this, you should have a file `hd_vila.parquet` with all the relevan
 To download the videos on clariden, just run video2dataset with the [default download config for clariden](../configs/download_clariden.yaml): From the login node, execute the following command, adapting the paths if necessary
 
 ```
-video2dataset --url_list="hd_vila.parquet" --config="swiss_ai/configs/download_clariden.yaml" --output_folder="./hd_vila_v2d" --input_format="parquet" --output_format="webdataset" --url_col="url" --encode_formats="{'video': 'mp4', 'audio':'m4a'}" 
+video2dataset --url_list="hd_vila.parquet" --config="swiss_ai/configs/download_clariden.yaml" --output_folder="./hd_vila_v2d" --input_format="parquet" --output_format="webdataset" --url_col="url" --encode_formats="{'video': 'mp4', 'audio':'m4a'}"
 ```
 
 This should run at a speed of roughly 500 videos/min or 40 GB/min. For further speedups, consider parallelizing over more nodes.
 
 Also, note that unlike in [dataset_examples/HDVILA.md](/dataset_examples/HDVILA.md) we're not performing cut detection while downloading (at least in the default clariden download config). Cut detection seemed to slow things down considerably and we rather want to perform any such processing on the final combined dataset.
-
-# [HDVILA-100M](https://github.com/microsoft/XPretrain/tree/main/hd-vila-100m)
-Page adapted from [dataset_examples/HDVILA.md](/dataset_examples/HDVILA.md).
-
-HDVILA 100M is a dataset of 3.3M high-resolution videos from YouTube, divided into 100M clips.
-
-## Download the metdata
-First, run `wget -O hdvila100m.zip https://hdvila.blob.core.windows.net/dataset/hdvila100m.zip?sp=r&st=2022-06-28T03:33:11Z&se=2026-01-01T11:33:11Z&spr=https&sv=2021-06-08&sr=b&sig=VaqQkLFDqKinfkaPNs1jJ1EQIYCB%2FUPYiqFqmjWye6Y%3D` to download the HD VILA 100M metadata. Next, just run `unzip hdvilla100m.zip` in order to unzip the metadata. You should now have an `hdvila100m/` directory.
-
-Next, we need to do some preprocessing to get this metadata formatted into a nice parquet. The following script will take the downloaded metadata `.jsonl` files and create a parquet with all the relevant information.
-
-```python
-import pandas as pd
-import glob
-import json
-import os
-import time
-from datetime import datetime
-
-def time_string_to_seconds(timestamp):
-    hh,mm,s = timestamp.split(':')
-    ss,ms = s.split('.')
-    time = 3600*int(hh) +  60*int(mm) + int(ss) + int(ms)/1000
-    return time
-
-def convert_clip_list(clip_list):
-    return [[time_string_to_seconds(x) for x in clip] for clip in clip_list]
-
-parquet_dir = "/path/to/my/metadata/dir/"
-
-data = []
-for jsonl in sorted(glob.glob(f"{parquet_dir}*.jsonl")):
-    path = os.path.join(parquet_dir, jsonl)
-    with open(path, "r") as f:
-        for line in f:
-            json_obj = json.loads(line)
-            clips = [
-                json_obj['clip'][i]['span']
-                for i in range(len(json_obj['clip']))
-            ]
-
-            out = {
-                'video_id': json_obj['video_id'],
-                'url': json_obj['url'],
-                'clips': clips
-            }
-            data.append(out)
-
-df = pd.DataFrame(data)
-df['clips'] = df['clips'].map(lambda x: convert_clip_list(x))
-df.to_parquet("hd_vila.parquet")
-```
-
-Once you run this, you should have a file `hd_vila.parquet` with all the relevant metadata.
-
-## Download the Videos
-To download the videos on clariden, just run video2dataset with the [default download config for clariden](../configs/download_clariden.yaml): From the login node, execute the following command, adapting the paths if necessary
-
-```
-video2dataset --url_list="hd_vila.parquet" --config="swissai/configs/download_clariden.yaml" --output_folder="./hd_vila_v2d" --input_format="parquet" --output_format="webdataset" --url_col="url" --encode_formats="{'video': 'mp4', 'audio':'m4a'}" 
-```
-
-This should run at a speed of roughly 500 videos/min or 40 GB/min. For further speedups, consider parallelizing over more nodes.
-
-Also, note that unlike in [dataset_examples/HDVILA.md](/dataset_examples/HDVILA.md) we're not performing cut detection while downloading (at least in the default clariden download config). Cut detection seemed to slow things down considerably and we rather want to perform any such processing on the final combined dataset.
-

--- a/swiss_ai/datasets/HowTo100M.md
+++ b/swiss_ai/datasets/HowTo100M.md
@@ -4,11 +4,11 @@ HowTo100M is a dataset of 136M video clips with captions sourced from 1.2M Youtu
 ## Download the raw metadata
 First, run `wget https://www.rocq.inria.fr/cluster-willow/amiech/howto100m/HowTo100M.zip`
 
-Second, run `python utils/process_howto100m.py -P <RAW ZIP PATH> -O /cluster/work/cotterell/mm_swissai/datasets/howto100m/v2d` to preprocess the zip file into a CSV compatible with video2dataset. Note the args for passing in the correct path to the zip and an output dir, as well as optional start/end indices.
+Second, run `python utils/process_howto100m.py -P <RAW ZIP PATH> -O /cluster/work/cotterell/mm_swissai/datasets/howto100m/v2d` to preprocess the zip file into a CSV compatible with video2dataset, and then download the videos in video2dataset format. Note the args for passing in the correct path to the zip and an output dir, as well as optional start/end indices.
 This will result in a file `/cluster/work/cotterell/mm_swissai/datasets/howto100m/v2d/howto100m_v2d.csv` (or, if you pass in start and end indices, `/cluster/work/cotterell/mm_swissai/datasets/howto100m/v2d/howto100m_v2d_<STARTINDEX>_<ENDINDEX>`).
 
-## Download the Videos
-To download the videos on clariden, just run video2dataset with the [default download config for clariden](../configs/download_clariden.yaml): From the login node, execute the following command, adapting the paths if necessary
+## Download the Videos (from CLI)
+While the python script will already download the videos, if you want to download the videos on clariden from CLI given the CSV, just run video2dataset with the [default download config for clariden](../configs/download_clariden.yaml): From the login node, execute the following command, adapting the paths if necessary
 
 ```
 video2dataset --url_list="/cluster/work/cotterell/mm_swissai/datasets/howto100m/v2d/howto100m_v2d_0_5000.csv" --config="swiss_ai/configs/download_clariden.yaml" --output_folder="/cluster/work/cotterell/mm_swissai/datasets/howto100m/v2d" --input_format="csv" --output_format="webdataset" --url_col="video_link" --encode_formats="{'video': 'mp4', 'audio':'m4a'}"

--- a/swiss_ai/datasets/HowTo100M.md
+++ b/swiss_ai/datasets/HowTo100M.md
@@ -4,7 +4,7 @@ HowTo100M is a dataset of 136M video clips with captions sourced from 1.2M Youtu
 ## Download the raw metadata
 First, run `wget https://www.rocq.inria.fr/cluster-willow/amiech/howto100m/HowTo100M.zip`
 
-Second, run `python utils/process_howto100m.py -P <RAW ZIP PATH> -O /cluster/work/cotterell/mm_swissai/datasets/howto100m/v2d` to preprocess the zip file into a CSV compatible with video2dataset, and then download the videos in video2dataset format. Note the args for passing in the correct path to the zip and an output dir, as well as optional start/end indices.
+Second, run `python utils/process_howto100m.py -P <RAW ZIP PATH> -O /cluster/work/cotterell/mm_swissai/datasets/howto100m/v2d -VD` to preprocess the zip file into a CSV compatible with video2dataset, and then download the videos in video2dataset format (if you don't want to download, exclude the `-VD` flag). Note the args for passing in the correct path to the zip and an output dir, as well as optional start/end indices.
 This will result in a file `/cluster/work/cotterell/mm_swissai/datasets/howto100m/v2d/howto100m_v2d.csv` (or, if you pass in start and end indices, `/cluster/work/cotterell/mm_swissai/datasets/howto100m/v2d/howto100m_v2d_<STARTINDEX>_<ENDINDEX>`).
 
 ## Download the Videos (from CLI)

--- a/swiss_ai/datasets/HowTo100M.md
+++ b/swiss_ai/datasets/HowTo100M.md
@@ -1,0 +1,15 @@
+# [HowTo100M](https://github.com/antoine77340/howto100m)
+HowTo100M is a dataset of 136M video clips with captions sourced from 1.2M Youtube videos, across 23k activities from domains such as cooking, hand crafting, personal care, gardening or fitness.
+
+## Download the raw metadata
+First, run `wget https://www.rocq.inria.fr/cluster-willow/amiech/howto100m/HowTo100M.zip`
+
+Second, run `python utils/process_howto100m.py -P <RAW ZIP PATH> -O /cluster/work/cotterell/mm_swissai/datasets/howto100m/v2d` to preprocess the zip file into a CSV compatible with video2dataset. Note the args for passing in the correct path to the zip and an output dir, as well as optional start/end indices.
+This will result in a file `/cluster/work/cotterell/mm_swissai/datasets/howto100m/v2d/howto100m_v2d.csv` (or, if you pass in start and end indices, `/cluster/work/cotterell/mm_swissai/datasets/howto100m/v2d/howto100m_v2d_<STARTINDEX>_<ENDINDEX>`).
+
+## Download the Videos
+To download the videos on clariden, just run video2dataset with the [default download config for clariden](../configs/download_clariden.yaml): From the login node, execute the following command, adapting the paths if necessary
+
+```
+video2dataset --url_list="/cluster/work/cotterell/mm_swissai/datasets/howto100m/v2d/howto100m_v2d_0_5000.csv" --config="swiss_ai/configs/download_clariden.yaml" --output_folder="/cluster/work/cotterell/mm_swissai/datasets/howto100m/v2d" --input_format="csv" --output_format="webdataset" --url_col="video_link" --encode_formats="{'video': 'mp4', 'audio':'m4a'}"
+```

--- a/swiss_ai/utils/process_howto100m.py
+++ b/swiss_ai/utils/process_howto100m.py
@@ -10,6 +10,7 @@ from video2dataset import video2dataset
 def main():
     """
     Starting from the HowTo100M.zip file (download from https://www.di.ens.fr/willow/research/howto100m/), produces a csv in the format expected by video2dataset.
+    Optionally also converts to video2dataset format with the -VD flag.
     """
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -20,13 +21,23 @@ def main():
     )
     parser.add_argument("-S", "--start_idx", type=int, default=0)
     parser.add_argument("-E", "--end_idx", type=int)
+    parser.add_argument(
+        "-VD", "--run_v2d", action="store_false", help="Whether to run video2dataset on the created files"
+    )
+
     args = parser.parse_args()
-    raw_zip_path, out_dir, start_idx, end_idx = args.raw_zip_path, args.out_dir, args.start_idx, args.end_idx
+    raw_zip_path, out_dir, start_idx, end_idx, run_v2d = (
+        args.raw_zip_path,
+        args.out_dir,
+        args.start_idx,
+        args.end_idx,
+        args.run_v2d,
+    )
 
     # check if the output directory exists and is empty
     if os.path.exists(out_dir):
         if len(os.listdir(out_dir)) != 0:
-            raise ValueError(f"Expected out_dir to be empty, instead has {len(os.listdir(out_dir))} files.")
+            raise ValueError(f"Expected out_dir {out_dir} to be empty, instead has {len(os.listdir(out_dir))} files.")
     else:
         os.makedirs(out_dir)
 
@@ -61,17 +72,18 @@ def main():
         index=False,
     )
 
-    print("Converting to video2dataset")
-    # Convert to v2d format
-    video2dataset(
-        url_list=csv_path,
-        output_folder=out_dir,
-        config="swiss_ai/configs/download_clariden.yaml",
-        input_format="csv",
-        output_format="webdataset",
-        url_col="video_link",
-        encode_formats=dict(video="mp4", audio="m4a"),
-    )
+    if run_v2d:
+        print("Converting to video2dataset")
+        # Convert to v2d format
+        video2dataset(
+            url_list=csv_path,
+            output_folder=out_dir,
+            config="swiss_ai/configs/download_clariden.yaml",
+            input_format="csv",
+            output_format="webdataset",
+            url_col="video_link",
+            encode_formats=dict(video="mp4", audio="m4a"),
+        )
 
 
 if __name__ == "__main__":

--- a/swiss_ai/utils/process_howto100m.py
+++ b/swiss_ai/utils/process_howto100m.py
@@ -17,12 +17,12 @@ def main():
         "-P", "--raw_zip_path", type=str, default="/cluster/work/cotterell/mm_swissai/datasets/howto100m/HowTo100M.zip"
     )
     parser.add_argument(
-        "-O", "--out_dir", type=str, default="/cluster/work/cotterell/mm_swissai/datasets/howto100m/v2d_30000"
+        "-O", "--out_dir", type=str, default="/cluster/work/cotterell/mm_swissai/datasets/howto100m/v2d"
     )
     parser.add_argument("-S", "--start_idx", type=int, default=0)
     parser.add_argument("-E", "--end_idx", type=int)
     parser.add_argument(
-        "-VD", "--run_v2d", action="store_false", help="Whether to run video2dataset on the created files"
+        "-VD", "--run_v2d", action="store_true", help="Whether to run video2dataset on the created files"
     )
 
     args = parser.parse_args()

--- a/swiss_ai/utils/process_howto100m.py
+++ b/swiss_ai/utils/process_howto100m.py
@@ -4,6 +4,7 @@ from tqdm import tqdm
 import argparse
 import zipfile
 import os
+from video2dataset import video2dataset
 
 
 def main():
@@ -15,7 +16,7 @@ def main():
         "-P", "--raw_zip_path", type=str, default="/cluster/work/cotterell/mm_swissai/datasets/howto100m/HowTo100M.zip"
     )
     parser.add_argument(
-        "-O", "--out_dir", type=str, default="/cluster/work/cotterell/mm_swissai/datasets/howto100m/v2d"
+        "-O", "--out_dir", type=str, default="/cluster/work/cotterell/mm_swissai/datasets/howto100m/v2d_30000"
     )
     parser.add_argument("-S", "--start_idx", type=int, default=0)
     parser.add_argument("-E", "--end_idx", type=int)
@@ -48,14 +49,28 @@ def main():
         }
         flat_data.append(row)
     v2d_df = pd.DataFrame(flat_data)
+
+    csv_path = os.path.join(
+        out_dir,
+        f"howto100m_v2d_{start_idx}_{end_idx}.csv"
+        if start_idx != 0 or end_idx != len(captions_dict)
+        else "howto100m_v2d.csv",
+    )
     v2d_df.to_csv(
-        os.path.join(
-            out_dir,
-            f"howto100m_v2d_{start_idx}_{end_idx}.csv"
-            if start_idx != 0 or end_idx != len(captions_dict)
-            else "howto100m_v2d.csv",
-        ),
+        csv_path,
         index=False,
+    )
+
+    print("Converting to video2dataset")
+    # Convert to v2d format
+    video2dataset(
+        url_list=csv_path,
+        output_folder=out_dir,
+        config="swiss_ai/configs/download_clariden.yaml",
+        input_format="csv",
+        output_format="webdataset",
+        url_col="video_link",
+        encode_formats=dict(video="mp4", audio="m4a"),
     )
 
 

--- a/swiss_ai/utils/process_howto100m.py
+++ b/swiss_ai/utils/process_howto100m.py
@@ -1,0 +1,63 @@
+import pandas as pd
+import json
+from tqdm import tqdm
+import argparse
+import zipfile
+import os
+
+
+def main():
+    """
+    Starting from the HowTo100M.zip file (download from https://www.di.ens.fr/willow/research/howto100m/), produces a csv in the format expected by video2dataset.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-P", "--raw_zip_path", type=str, default="/cluster/work/cotterell/mm_swissai/datasets/howto100m/HowTo100M.zip"
+    )
+    parser.add_argument(
+        "-O", "--out_dir", type=str, default="/cluster/work/cotterell/mm_swissai/datasets/howto100m/v2d"
+    )
+    parser.add_argument("-S", "--start_idx", type=int, default=0)
+    parser.add_argument("-E", "--end_idx", type=int)
+    args = parser.parse_args()
+    raw_zip_path, out_dir, start_idx, end_idx = args.raw_zip_path, args.out_dir, args.start_idx, args.end_idx
+
+    # check if the output directory exists and is empty
+    if os.path.exists(out_dir):
+        if len(os.listdir(out_dir)) != 0:
+            raise ValueError(f"Expected out_dir to be empty, instead has {len(os.listdir(out_dir))} files.")
+    else:
+        os.makedirs(out_dir)
+
+    with zipfile.ZipFile(raw_zip_path, "r") as zip_ref:
+        print("Analyzing zip file...")
+        # read categories
+        with zip_ref.open("caption.json") as f:
+            captions_dict = json.load(f)
+
+    flat_data = []
+    if end_idx is None:
+        end_idx = len(captions_dict)
+
+    for video_id, captions in list(captions_dict.items())[start_idx:end_idx]:
+        row = {
+            "video_id": video_id,
+            "video_link": f"https://youtube.com/watch?v={video_id}",
+            "clips": [[a, b] for a, b in zip(captions["start"], captions["end"])],
+            "text": captions["text"],
+        }
+        flat_data.append(row)
+    v2d_df = pd.DataFrame(flat_data)
+    v2d_df.to_csv(
+        os.path.join(
+            out_dir,
+            f"howto100m_v2d_{start_idx}_{end_idx}.csv"
+            if start_idx != 0 or end_idx != len(captions_dict)
+            else "howto100m_v2d.csv",
+        ),
+        index=False,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/swiss_ai/utils/process_mit.py
+++ b/swiss_ai/utils/process_mit.py
@@ -15,28 +15,27 @@ def main():
     args = parser.parse_args()
     raw_zip_path, out_dir = args.raw_zip_path, args.out_dir
 
-
     # check if the output directory exists and is empty
     if os.path.exists(out_dir):
         assert len(os.listdir(out_dir)) == 0
     else:
         os.makedirs(out_dir)
 
-    with zipfile.ZipFile(raw_zip_path, 'r') as zip_ref:
+    with zipfile.ZipFile(raw_zip_path, "r") as zip_ref:
 
         print("Analyzing zip file...")
 
         # read categories
         with zip_ref.open("Moments_in_Time_Raw/moments_categories.txt") as f:
-            df_classes = pd.read_csv(f, usecols=[0, 1], names=['name', 'id'])
+            df_classes = pd.read_csv(f, usecols=[0, 1], names=["name", "id"])
             df_classes.set_index("id", inplace=True)
         print(f"Found {len(df_classes)} classes")
 
         # read index files
         with zip_ref.open("Moments_in_Time_Raw/trainingSet.csv") as f:
-            df_train = pd.read_csv(f, usecols=[0, 1, 2, 3], names=['filename', 'label', 'Responses 1', 'Responses 2'])
+            df_train = pd.read_csv(f, usecols=[0, 1, 2, 3], names=["filename", "label", "Responses 1", "Responses 2"])
         with zip_ref.open("Moments_in_Time_Raw/validationSet.csv") as f:
-            df_val = pd.read_csv(f, usecols=[0, 1, 2, 3], names=['filename', 'label', 'Responses 1', 'Responses 2'])
+            df_val = pd.read_csv(f, usecols=[0, 1, 2, 3], names=["filename", "label", "Responses 1", "Responses 2"])
         df_train["path"] = "Moments_in_Time_Raw/training/" + df_train["filename"]
         df_val["path"] = "Moments_in_Time_Raw/validation/" + df_val["filename"]
         df_train["original_split"] = "training"
@@ -122,7 +121,6 @@ def main():
             df_class_metadata.to_parquet(os.path.join(out_dir, class_parquet_fname), index=False)
 
         print(f"Done, #success {n_success}, #failed {n_failures}")
-
 
 
 if __name__ == "__main__":

--- a/video2dataset/distributor.py
+++ b/video2dataset/distributor.py
@@ -210,7 +210,6 @@ class SlurmDistributor:
 #SBATCH --nodes={self.n_nodes}
 #SBATCH --ntasks-per-node={self.tasks_per_node}
 #SBATCH --cpus-per-task={self.cpus_per_task}
-#SBATCH --gpus-per-node={self.gpus_per_node}
 #SBATCH --exclusive
 {nodelist}
 {exclude}
@@ -231,7 +230,7 @@ srun --account {self.account} bash {self.launcher_path}
         if venv:
             venv_activate = f"source {venv}/bin/activate"
         else:
-            conda_env = os.environ.get("CONDA_ENV")
+            conda_env = os.environ.get("CONDA_ENV", os.environ.get("CONDA_PREFIX"))
             if conda_env:
                 venv_activate = f"conda activate {conda_env}"
             else:


### PR DESCRIPTION
Describes steps to download HowTo100M and convert it into video2dataset format.
A few decisions:
* I liked the HD-Vila interface for starting from the zip file and `out_dir` and then spitting out the results there, so I followed that pattern here.
* I did not cut the clips because that makes those videos all just a few seconds long. This follows the HD-Vila pattern as well.
* I also didn't include certain metadata like video titles and task categories. I can include if that's projected to be useful but since we're just pretraining I figured it didn't matter too much?

(For now, diffing against anton/mit-and-vila so you can clearly see the changes; once that's merged I'll rebase on main and we can diff there)