### PR TITLE
Reconfigure video2dataset swiss_ai settings for the todi cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,10 @@ You can also log in (or create an account) before by running `wandb login`.
 
 Either locally, or in [gitpod](https://gitpod.io/#https://github.com/iejMac/video2dataset) (do `export PIP_USER=false` there)
 
+FOR TODI: you need to use the `requirements_todi.txt`. To do this, uncomment the line setting `REQUIREMENTS = _read_reqs("requirements_todi.txt")` in `setup.py` first.
+
+FOR ANY OTHER SYSTEM: proceed as normal!
+
 Setup a virtualenv:
 
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pandas
 tqdm
 timeout-decorator
 scenedetect[opencv]==0.6.2
-decord
+#decord
 #eva-decord  # use eva-decord instead of decord on Mac (https://github.com/dmlc/decord/issues/213)
 torch==2.2.0
 langdetect

--- a/requirements_todi.txt
+++ b/requirements_todi.txt
@@ -12,7 +12,7 @@ pandas
 tqdm
 timeout-decorator
 scenedetect[opencv]==0.6.2
-decord
+#decord # NOTE: THIS IS ONLY FOR TODI BECAUSE THE ARM PROCESSOR THERE CAN'T USE DECORD. MUST INSTALL DECORD FROM SOURCE INSTEAD ON TODI. FOR OTHER SYSTEMS UNCOMMENT THIS.
 #eva-decord  # use eva-decord instead of decord on Mac (https://github.com/dmlc/decord/issues/213)
 torch==2.2.0
 langdetect

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ if __name__ == "__main__":
             return [s.strip() for s in f.readlines() if (s.strip() and not s.startswith("#"))]
 
     REQUIREMENTS = _read_reqs("requirements.txt")
+    # REQUIREMENTS = _read_reqs("requirements_todi.txt")
 
     setup(
         name="video2dataset",

--- a/swiss_ai/configs/download_clariden.yaml
+++ b/swiss_ai/configs/download_clariden.yaml
@@ -32,4 +32,4 @@ distribution:
         cpus_per_task: 128 # 1 node has 128 cores
         tasks_per_node: 1
         job_name: "v2d"
-        environment: "v2d"
+        environment: "/store/swissai/a08/containers/v2d/v2d.toml"

--- a/swiss_ai/configs/download_todi.yaml
+++ b/swiss_ai/configs/download_todi.yaml
@@ -29,7 +29,7 @@ distribution:
         n_nodes: 4
         account: null
         cache_path: "./slurm_cache"
-        cpus_per_task: 128 # 1 node has 128 cores
-        tasks_per_node: 1
+        cpus_per_task: 128 # 1 node has 288 cores total
+        tasks_per_node: 2
         job_name: "v2d"
         environment: "v2d"

--- a/swiss_ai/configs/download_todi.yaml
+++ b/swiss_ai/configs/download_todi.yaml
@@ -35,7 +35,7 @@ distribution:
         environment: "/store/swissai/a08/containers/v2d/v2d.toml"
 # NOTES:
 # (according to `sacct --format=JobID,JobName,State,Elapsed`)
-#   When cpus_per_task=256 and tasks_per_node=1, with 4 nodes it took 5 min to run for 1000 videos. (jobid=38589)
+#   When cpus_per_task=256 and tasks_per_node=1, with 4 nodes it took 5 min to run for 1000 videos. (jobids=38589, 39203)
 #   When cpus_per_task=128 and tasks_per_node=2, with 4 nodes it took 6-7 min to run for 1000 videos. (jobid=36187)
 #   When cpus_per_task=64 and tasks_per_node=4, with 4 nodes it took 12 min to run for 1000 videos. (jobid=36785)
 #   When cpus_per_task=32 and tasks_per_node=8, with 4 nodes it failed with "too many open files" to run for 5000 videos.

--- a/swiss_ai/configs/download_todi.yaml
+++ b/swiss_ai/configs/download_todi.yaml
@@ -29,7 +29,8 @@ distribution:
         n_nodes: 4
         account: null
         cache_path: "./slurm_cache"
-        cpus_per_task: 128 # 1 node has 288 cores total
+        cpus_per_task: 128 # 1 node has 288 cores total, so try 16 * 16 = 256 < 288
         tasks_per_node: 2
         job_name: "v2d"
         environment: "/store/swissai/a08/containers/v2d/v2d.toml"
+# NOTES: when cpus_per_task=128 and tasks_per_node=2, with 4 nodes it took 7 min to run for 1000 videos.

--- a/swiss_ai/configs/download_todi.yaml
+++ b/swiss_ai/configs/download_todi.yaml
@@ -32,4 +32,4 @@ distribution:
         cpus_per_task: 128 # 1 node has 288 cores total
         tasks_per_node: 2
         job_name: "v2d"
-        environment: "v2d"
+        environment: "/store/swissai/a08/containers/v2d/v2d.toml"

--- a/swiss_ai/configs/download_todi.yaml
+++ b/swiss_ai/configs/download_todi.yaml
@@ -26,7 +26,7 @@ distribution:
     distributor: "slurm"
     distributor_args:
         partition: "normal"
-        n_nodes: 4
+        n_nodes: 1
         account: null
         cache_path: "./slurm_cache"
         cpus_per_task: 256 # 1 node has 288 cores total
@@ -35,6 +35,7 @@ distribution:
         environment: "/store/swissai/a08/containers/v2d/v2d.toml"
 # NOTES:
 # (according to `sacct --format=JobID,JobName,State,Elapsed`)
+#   When cpus_per_task=256 and tasks_per_node=1, with 1 nodes it took 5-6 min to run for 1000 videos. (jobids=39660)
 #   When cpus_per_task=256 and tasks_per_node=1, with 4 nodes it took 5 min to run for 1000 videos. (jobids=38589, 39203)
 #   When cpus_per_task=128 and tasks_per_node=2, with 4 nodes it took 6-7 min to run for 1000 videos. (jobid=36187)
 #   When cpus_per_task=64 and tasks_per_node=4, with 4 nodes it took 12 min to run for 1000 videos. (jobid=36785)

--- a/swiss_ai/configs/download_todi.yaml
+++ b/swiss_ai/configs/download_todi.yaml
@@ -15,7 +15,7 @@ reading:
     sampler: null
 
 storage:
-    number_sample_per_shard: 100  # reduce this if you're not downloading thousands of videos to allow for enough parallelsim
+    number_sample_per_shard: 20  # TBD what the best number is, for now making it smaller for improved parallelism # reduce this if you're not downloading thousands of videos to allow for enough parallelsim
     oom_shard_count: 10
     captions_are_subtitles: False
 

--- a/swiss_ai/configs/download_todi.yaml
+++ b/swiss_ai/configs/download_todi.yaml
@@ -33,4 +33,9 @@ distribution:
         tasks_per_node: 2
         job_name: "v2d"
         environment: "/store/swissai/a08/containers/v2d/v2d.toml"
-# NOTES: when cpus_per_task=128 and tasks_per_node=2, with 4 nodes it took 7 min to run for 1000 videos.
+# NOTES:
+# (according to `sacct --format=JobID,JobName,State,Elapsed`)
+#   When cpus_per_task=128 and tasks_per_node=2, with 4 nodes it took 7 min to run for 1000 videos. (jobid=36187)
+#   When cpus_per_task=64 and tasks_per_node=4, with 4 nodes it took 12 min to run for 1000 videos. (jobid=36785)
+#   When cpus_per_task=32 and tasks_per_node=8, with 4 nodes it failed with "too many open files" to run for 5000 videos.
+# ***Thus, it seems like best bet is cpus_per_task=128 and tasks_per_node=2***.

--- a/swiss_ai/configs/download_todi.yaml
+++ b/swiss_ai/configs/download_todi.yaml
@@ -29,13 +29,14 @@ distribution:
         n_nodes: 4
         account: null
         cache_path: "./slurm_cache"
-        cpus_per_task: 128 # 1 node has 288 cores total, so try 16 * 16 = 256 < 288
-        tasks_per_node: 2
+        cpus_per_task: 256 # 1 node has 288 cores total
+        tasks_per_node: 1
         job_name: "v2d"
         environment: "/store/swissai/a08/containers/v2d/v2d.toml"
 # NOTES:
 # (according to `sacct --format=JobID,JobName,State,Elapsed`)
-#   When cpus_per_task=128 and tasks_per_node=2, with 4 nodes it took 7 min to run for 1000 videos. (jobid=36187)
+#   When cpus_per_task=256 and tasks_per_node=1, with 4 nodes it took 5 min to run for 1000 videos. (jobid=38589)
+#   When cpus_per_task=128 and tasks_per_node=2, with 4 nodes it took 6-7 min to run for 1000 videos. (jobid=36187)
 #   When cpus_per_task=64 and tasks_per_node=4, with 4 nodes it took 12 min to run for 1000 videos. (jobid=36785)
 #   When cpus_per_task=32 and tasks_per_node=8, with 4 nodes it failed with "too many open files" to run for 5000 videos.
 # ***Thus, it seems like best bet is cpus_per_task=128 and tasks_per_node=2***.

--- a/swiss_ai/datasets/HDVILA.md
+++ b/swiss_ai/datasets/HDVILA.md
@@ -58,7 +58,12 @@ To download the videos on todi, just run video2dataset with the [default downloa
 ```
 video2dataset --url_list="/store/swissai/a08/data/raw/hdvila/hd_vila.parquet" --config="/store/swissai/a08/containers/v2d/video2dataset/swiss_ai/configs/download_todi.yaml" --output_folder="/store/swissai/a08/data/raw/hdvila/hd_vila_v2d" --input_format="parquet" --output_format="webdataset" --url_col="url" --encode_formats="{'video': 'mp4', 'audio':'m4a'}"
 ```
+OR with `srun`:
+```
+srun --overlap --jobid=<JOBID> --environment=v2d --container-workdir=$PWD video2dataset --url_list="/store/swissai/a08/data/raw/hdvila/hd_vila.parquet" --config="/store/swissai/a08/containers/v2d/video2dataset/swiss_ai/configs/download_todi.yaml" --output_folder="/store/swissai/a08/data/raw/hdvila/hd_vila_v2d" --input_format="parquet" --output_format="webdataset" --url_col="url" --encode_formats="{'video': 'mp4', 'audio':'m4a'}"
+```
 
 This should run at a speed of roughly 500 videos/min or 40 GB/min. For further speedups, consider parallelizing over more nodes.
 
 Also, note that unlike in [dataset_examples/HDVILA.md](/dataset_examples/HDVILA.md) we're not performing cut detection while downloading (at least in the default clariden download config). Cut detection seemed to slow things down considerably and we rather want to perform any such processing on the final combined dataset.
+

--- a/swiss_ai/datasets/HDVILA.md
+++ b/swiss_ai/datasets/HDVILA.md
@@ -53,10 +53,10 @@ df.to_parquet("hd_vila.parquet")
 Once you run this, you should have a file `hd_vila.parquet` with all the relevant metadata.
 
 ## Download the Videos
-To download the videos on clariden, just run video2dataset with the [default download config for clariden](../configs/download_clariden.yaml): From the login node, execute the following command, adapting the paths if necessary
+To download the videos on todi, just run video2dataset with the [default download config for todi](../configs/download_todi.yaml): From the login node, execute the following command, adapting the paths if necessary
 
 ```
-video2dataset --url_list="hd_vila.parquet" --config="swiss_ai/configs/download_clariden.yaml" --output_folder="./hd_vila_v2d" --input_format="parquet" --output_format="webdataset" --url_col="url" --encode_formats="{'video': 'mp4', 'audio':'m4a'}"
+video2dataset --url_list="/store/swissai/a08/data/raw/hdvila/hd_vila.parquet" --config="/store/swissai/a08/containers/v2d/video2dataset/swiss_ai/configs/download_todi.yaml" --output_folder="/store/swissai/a08/data/raw/hdvila/hd_vila_v2d" --input_format="parquet" --output_format="webdataset" --url_col="url" --encode_formats="{'video': 'mp4', 'audio':'m4a'}"
 ```
 
 This should run at a speed of roughly 500 videos/min or 40 GB/min. For further speedups, consider parallelizing over more nodes.

--- a/swiss_ai/datasets/HowTo100M.md
+++ b/swiss_ai/datasets/HowTo100M.md
@@ -8,8 +8,8 @@ Second, run `python utils/process_howto100m.py -P <RAW ZIP PATH> -O /cluster/wor
 This will result in a file `/cluster/work/cotterell/mm_swissai/datasets/howto100m/v2d/howto100m_v2d.csv` (or, if you pass in start and end indices, `/cluster/work/cotterell/mm_swissai/datasets/howto100m/v2d/howto100m_v2d_<STARTINDEX>_<ENDINDEX>`).
 
 ## Download the Videos (from CLI)
-While the python script will already download the videos, if you want to download the videos on clariden from CLI given the CSV, just run video2dataset with the [default download config for clariden](../configs/download_clariden.yaml): From the login node, execute the following command, adapting the paths if necessary
+While the python script will already download the videos, if you want to download the videos on todi from CLI given the CSV, just run video2dataset with the [default download config for todi](../configs/download_todi.yaml): From the login node, execute the following command, adapting the paths if necessary. Make sure all paths are absolute because the v2d utility will cd around and relative dirs might mess things up a bit.
 
 ```
-video2dataset --url_list="/cluster/work/cotterell/mm_swissai/datasets/howto100m/v2d/howto100m_v2d_0_5000.csv" --config="swiss_ai/configs/download_clariden.yaml" --output_folder="/cluster/work/cotterell/mm_swissai/datasets/howto100m/v2d" --input_format="csv" --output_format="webdataset" --url_col="video_link" --encode_formats="{'video': 'mp4', 'audio':'m4a'}"
+video2dataset --url_list="/store/swissai/a08/data/raw/howto100m/v2d/howto100m_v2d_0_5000.csv" --config="/store/swissai/a08/containers/v2d/video2dataset/swiss_ai/configs/download_todi.yaml" --output_folder="/store/swissai/a08/data/raw/howto100m/v2d" --input_format="csv" --output_format="webdataset" --url_col="video_link" --encode_formats="{'video': 'mp4', 'audio':'m4a'}"
 ```

--- a/swiss_ai/datasets/HowTo100M.md
+++ b/swiss_ai/datasets/HowTo100M.md
@@ -13,3 +13,8 @@ While the python script will already download the videos, if you want to downloa
 ```
 video2dataset --url_list="/store/swissai/a08/data/raw/howto100m/v2d/howto100m_v2d_0_5000.csv" --config="/store/swissai/a08/containers/v2d/video2dataset/swiss_ai/configs/download_todi.yaml" --output_folder="/store/swissai/a08/data/raw/howto100m/v2d" --input_format="csv" --output_format="webdataset" --url_col="video_link" --encode_formats="{'video': 'mp4', 'audio':'m4a'}"
 ```
+
+OR with `srun`:
+```
+srun --overlap --jobid=<JOBID> --environment=v2d --container-workdir=$PWD video2dataset --url_list="/store/swissai/a08/data/raw/howto100m/v2d/howto100m_v2d_0_5000.csv" --config="/store/swissai/a08/containers/v2d/video2dataset/swiss_ai/configs/download_todi.yaml" --output_folder="/store/swissai/a08/data/raw/howto100m/v2d" --input_format="csv" --output_format="webdataset" --url_col="video_link" --encode_formats="{'video': 'mp4', 'audio':'m4a'}"
+```

--- a/swiss_ai/datasets/HowTo100M.md
+++ b/swiss_ai/datasets/HowTo100M.md
@@ -4,8 +4,8 @@ HowTo100M is a dataset of 136M video clips with captions sourced from 1.2M Youtu
 ## Download the raw metadata
 First, run `wget https://www.rocq.inria.fr/cluster-willow/amiech/howto100m/HowTo100M.zip`
 
-Second, run `python utils/process_howto100m.py -P <RAW ZIP PATH> -O /cluster/work/cotterell/mm_swissai/datasets/howto100m/v2d -VD` to preprocess the zip file into a CSV compatible with video2dataset, and then download the videos in video2dataset format (if you don't want to download, exclude the `-VD` flag). Note the args for passing in the correct path to the zip and an output dir, as well as optional start/end indices.
-This will result in a file `/cluster/work/cotterell/mm_swissai/datasets/howto100m/v2d/howto100m_v2d.csv` (or, if you pass in start and end indices, `/cluster/work/cotterell/mm_swissai/datasets/howto100m/v2d/howto100m_v2d_<STARTINDEX>_<ENDINDEX>`).
+Second, run `python utils/process_howto100m.py -P <RAW ZIP PATH> -O /store/swissai/a08/data/raw/howto100m/v2d -VD` to preprocess the zip file into a CSV compatible with video2dataset, and then download the videos in video2dataset format (if you don't want to download, exclude the `-VD` flag). Note the args for passing in the correct path to the zip and an output dir, as well as optional start/end indices.
+This will result in a file `/store/swissai/a08/data/raw/howto100m/v2d/howto100m_v2d.csv` (or, if you pass in start and end indices, `/cluster/work/cotterell/mm_swissai/datasets/howto100m/v2d/howto100m_v2d_<STARTINDEX>_<ENDINDEX>`).
 
 ## Download the Videos (from CLI)
 While the python script will already download the videos, if you want to download the videos on todi from CLI given the CSV, just run video2dataset with the [default download config for todi](../configs/download_todi.yaml): From the login node, execute the following command, adapting the paths if necessary. Make sure all paths are absolute because the v2d utility will cd around and relative dirs might mess things up a bit.

--- a/swiss_ai/utils/process_hdvila.py
+++ b/swiss_ai/utils/process_hdvila.py
@@ -1,0 +1,40 @@
+import pandas as pd
+import glob
+import json
+import os
+import time
+from datetime import datetime
+
+def time_string_to_seconds(timestamp):
+    hh,mm,s = timestamp.split(':')
+    ss,ms = s.split('.')
+    time = 3600*int(hh) +  60*int(mm) + int(ss) + int(ms)/1000
+    return time
+
+def convert_clip_list(clip_list):
+    return [[time_string_to_seconds(x) for x in clip] for clip in clip_list]
+
+parquet_dir = "/store/swissai/a08/data/raw/hdvila/"
+
+data = []
+for jsonl in sorted(glob.glob(f"{parquet_dir}*.jsonl")):
+    path = os.path.join(parquet_dir, jsonl)
+    with open(path, "r") as f:
+        for line in f:
+            json_obj = json.loads(line)
+            clips = [
+                json_obj['clip'][i]['span']
+                for i in range(len(json_obj['clip']))
+            ]
+
+            out = {
+                'video_id': json_obj['video_id'],
+                'url': json_obj['url'],
+                'clips': clips
+            }
+            data.append(out)
+
+df = pd.DataFrame(data)
+print(df.info())
+df['clips'] = df['clips'].map(lambda x: convert_clip_list(x))
+df.to_parquet(os.path.join(parquet_dir, "hd_vila.parquet"))

--- a/swiss_ai/utils/process_howto100m.py
+++ b/swiss_ai/utils/process_howto100m.py
@@ -14,10 +14,10 @@ def main():
     """
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "-P", "--raw_zip_path", type=str, default="/cluster/work/cotterell/mm_swissai/datasets/howto100m/HowTo100M.zip"
+        "-P", "--raw_zip_path", type=str, default="/store/swissai/a08/data/raw/HowTo100M.zip"
     )
     parser.add_argument(
-        "-O", "--out_dir", type=str, default="/cluster/work/cotterell/mm_swissai/datasets/howto100m/v2d"
+        "-O", "--out_dir", type=str, default="/store/swissai/a08/data/raw/howto100m/v2d"
     )
     parser.add_argument("-S", "--start_idx", type=int, default=0)
     parser.add_argument("-E", "--end_idx", type=int)

--- a/swiss_ai/utils/process_howto100m.py
+++ b/swiss_ai/utils/process_howto100m.py
@@ -78,7 +78,7 @@ def main():
         video2dataset(
             url_list=csv_path,
             output_folder=out_dir,
-            config="swiss_ai/configs/download_clariden.yaml",
+            config="swiss_ai/configs/download_todi.yaml",
             input_format="csv",
             output_format="webdataset",
             url_col="video_link",

--- a/video2dataset/distributor.py
+++ b/video2dataset/distributor.py
@@ -307,14 +307,21 @@ python {script} --worker_args {self.worker_args_as_file} --node_id $SLURM_NODEID
 
             print(f"waiting for job {job_id}")
 
-            timeout = self.timeout
+            # Option 1: We set the timeout for the SlurmDistributor to two weeks because our slurm manager 
+            # on the todi cluster should already manage the timeout for us, and we don't want any 
+            # prematurely killed jobs from SlurmDistributor thinking we're timed out!
+            timeout = 1.21e6
 
-            if timeout is None:
-                print("You have not specified a timeout, defaulting to 2 weeks.")
-                timeout = 1.21e6
-            else:
-                print(f"Timeout specified as {timeout} minutes to the v2d SlurmDistributor.")
-                timeout *= 60 # since self.timeout is in minutes, we need to convert it to seconds here
+            # Option 2: We set the timeout to be the same as what we pass to our slurm manager, 
+            # but I think this might still mess up if the job has to wait because the counter here in SlurmDistributor 
+            # seems like it would already start while jobs are still in queue?
+            # timeout = self.timeout
+            # if timeout is None:
+            #     print("You have not specified a timeout, defaulting to 2 weeks.")
+            #     timeout = 1.21e6
+            # else:
+            #     print(f"Timeout specified as {timeout} minutes to the v2d SlurmDistributor.")
+            #     timeout *= 60 # since self.timeout is in minutes, we need to convert it to seconds here
 
             status = self._wait_for_job_to_finish(job_id=job_id, timeout=timeout)
 

--- a/video2dataset/distributor.py
+++ b/video2dataset/distributor.py
@@ -151,6 +151,7 @@ class SlurmDistributor:
         partition,
         n_nodes,
         account,
+        environment=None,
         gpus_per_node=0,
         tasks_per_node=1,
         nodelist=None,
@@ -166,6 +167,8 @@ class SlurmDistributor:
         self.n_nodes = n_nodes
         self.gpus_per_node = gpus_per_node
         self.account = account
+        self.environment = environment
+        print("ENV:", self.environment)
         self.tasks_per_node = tasks_per_node
         self.nodelist = nodelist
         self.constraint = constraint
@@ -217,7 +220,7 @@ class SlurmDistributor:
 {constraint}
 #SBATCH --open-mode append
 
-srun --account {self.account} bash {self.launcher_path}
+srun --environment={self.environment} --account {self.account} bash {self.launcher_path}
 
 """
 

--- a/video2dataset/distributor.py
+++ b/video2dataset/distributor.py
@@ -161,6 +161,9 @@ class SlurmDistributor:
         timeout=240,
         verbose_wait=False,
     ):
+        """
+        timeout - This is the timeout in MINUTES.
+        """
         self.cpus_per_task = cpus_per_task
         self.job_name = job_name
         self.partition = partition
@@ -309,6 +312,8 @@ python {script} --worker_args {self.worker_args_as_file} --node_id $SLURM_NODEID
             if timeout is None:
                 print("You have not specified a timeout, defaulting to 2 weeks.")
                 timeout = 1.21e6
+            else:
+                timeout *= 60 # since self.timeout is in minutes, we need to convert it to seconds here
 
             status = self._wait_for_job_to_finish(job_id=job_id, timeout=timeout)
 
@@ -326,6 +331,7 @@ python {script} --worker_args {self.worker_args_as_file} --node_id $SLURM_NODEID
             return "exception occurred"
 
     def _wait_for_job_to_finish(self, job_id, timeout=30):
+        # This expects timeout in SECONDS
         t = time.time()
         while 1:
             if time.time() - t > timeout:

--- a/video2dataset/distributor.py
+++ b/video2dataset/distributor.py
@@ -313,6 +313,7 @@ python {script} --worker_args {self.worker_args_as_file} --node_id $SLURM_NODEID
                 print("You have not specified a timeout, defaulting to 2 weeks.")
                 timeout = 1.21e6
             else:
+                print(f"Timeout specified as {timeout} minutes to the v2d SlurmDistributor.")
                 timeout *= 60 # since self.timeout is in minutes, we need to convert it to seconds here
 
             status = self._wait_for_job_to_finish(job_id=job_id, timeout=timeout)

--- a/video2dataset/distributor.py
+++ b/video2dataset/distributor.py
@@ -158,7 +158,7 @@ class SlurmDistributor:
         constraint=None,
         exclude=None,
         cache_path=None,
-        timeout=None,
+        timeout=1440,
         verbose_wait=False,
     ):
         self.cpus_per_task = cpus_per_task
@@ -213,6 +213,7 @@ class SlurmDistributor:
 #SBATCH --nodes={self.n_nodes}
 #SBATCH --ntasks-per-node={self.tasks_per_node}
 #SBATCH --cpus-per-task={self.cpus_per_task}
+#SBATCH --time={self.timeout}
 #SBATCH --exclusive
 {nodelist}
 {exclude}

--- a/video2dataset/distributor.py
+++ b/video2dataset/distributor.py
@@ -158,7 +158,7 @@ class SlurmDistributor:
         constraint=None,
         exclude=None,
         cache_path=None,
-        timeout=1440,
+        timeout=240,
         verbose_wait=False,
     ):
         self.cpus_per_task = cpus_per_task


### PR DESCRIPTION
### Summary
To download videos onto the todi cluster with video2dataset using slurm, we need to configure some specific settings.
This PR includes:
* the `download_todi.config`, which defines parameters to use for using slurm to execute video2dataset in parallel on many videos.
* updates to the commands you need to run to download howto100m and hdvila (NOT moments in time yet) in [swiss_ai/datasets/HowTo100M.md](https://github.com/swiss-ai/video2dataset/compare/main...swiss-ai:video2dataset:kdu/todi?expand=1#diff-8da0a1652a05c54e93eea5a4e14e5cc478837b2e9a23add8279c67f73f10dd7c) and [swiss_ai/datasets/HDVILA.md](https://github.com/swiss-ai/video2dataset/compare/main...swiss-ai:video2dataset:kdu/todi?expand=1#diff-b3e5c4ff774e331eb03256c835bd8bcb27dcedb92195ebc37d38874ac42a71b8).
* removing `decord` from requirements.txt because that needs to be installed from source on the GH200 arm processors (see https://github.com/swiss-ai/containers/blob/main/v2d/Dockerfile for where this is done).
* modifying the `distributor.py` file to include an environment variable (for which image to build the container with on todi) and a timeout variable.

I also did some quick tests on downloading small amounts of data of howto100m with different variations of num_tasks_per_node and num_cpus_per_task, detailed in the comments in the download_todi config file.


### Test strategy
1. [DONE] Ran `video2dataset --url_list="/store/swissai/a08/data/raw/howto100m/v2d/howto100m_v2d_0_1000.csv" --config="/store/swissai/a08/kdu/video2dataset/swiss_ai/configs/download_todi.yaml" --output_folder="/store/swissai/a08/data/raw/howto100m/v2d" --input_format="csv" --output_format="webdataset" --url_col="video_link" --encode_formats="{'video': 'mp4', 'audio':'m4a'}"` within a container started with `srun --overlap --jobid=<JOBID> --environment=v2d --container-workdir=$PWD --pty bash` to confirm that the data can be downloaded.
2. [TODO] Run `video2dataset --url_list="/store/swissai/a08/data/raw/howto100m/v2d_40k/howto100m
_v2d_0_40000.csv" --config="/store/swissai/a08/kdu/video2dataset/swiss_ai/configs/download_todi.yaml" --output_folder="/store/swissai/a08/data/raw/howto100m/v2d_40k" --input_format="csv" --output_format="webdataset" --url_col="vid
eo_link" --encode_formats="{'video': 'mp4', 'audio':'m4a'}"` (expected to finish in about 4 hours, the max time limit of a slurm job.). Job ID = 39836
3. [TODO] Run `srun --overlap --jobid=<JOBID> --environment=v2d --container-workdir=$PWD video2dataset --url_list="/store/swissai/a08/data/raw/howto100m/v2d/howto100m_v2d.csv" --config="/store/swissai/a08/containers/v2d/video2dataset/swiss_ai/configs/download_todi.yaml" --output_folder="/store/swissai/a08/data/raw/howto100m/v2d" --input_format="csv" --output_format="webdataset" --url_col="video_link" --encode_formats="{'video': 'mp4', 'audio':'m4a'}"` to download the full howto100m dataset.
4. [TODO] Run `srun --overlap --jobid=<JOBID> --environment=v2d --container-workdir=$PWD video2dataset --url_list="/store/swissai/a08/data/raw/hdvila/hd_vila.parquet" --config="/store/swissai/a08/containers/v2d/video2dataset/swiss_ai/configs/download_todi.yaml" --output_folder="/store/swissai/a08/data/raw/hdvila/hd_vila_v2d" --input_format="parquet" --output_format="webdataset" --url_col="url" --encode_formats="{'video': 'mp4', 'audio':'m4a'}"` to download the full hdvila dataset.